### PR TITLE
Update h-structured.py

### DIFF
--- a/ch1/py/h-structured.py
+++ b/ch1/py/h-structured.py
@@ -11,7 +11,7 @@ class AnswerWithJustification(BaseModel):
     """Justification for the answer"""
 
 
-llm = ChatOpenAI(model="gpt-3.5", temperature=0)
+llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
 structured_llm = llm.with_structured_output(AnswerWithJustification)
 
 response = structured_llm.invoke(

--- a/ch1/py/h-structured.py
+++ b/ch1/py/h-structured.py
@@ -11,7 +11,7 @@ class AnswerWithJustification(BaseModel):
     """Justification for the answer"""
 
 
-llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+llm = ChatOpenAI(model="gpt-4o-mini-2024-07-18", temperature=0)
 structured_llm = llm.with_structured_output(AnswerWithJustification)
 
 response = structured_llm.invoke(


### PR DESCRIPTION
The example is using structured outputs but a version of chatGPT that doesn't support structured outputs: https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#json-mode

The PR fixes the example so that it doesn't error out. Defer to owners on whether this is the right approach.